### PR TITLE
CA Certificates are also needed if the target swift uses https endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && \
     apk add wget ca-certificates && \
     wget -O /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
     chmod +x /bin/dumb-init && \
-    apk del wget ca-certificates
+    apk del wget
 
 ADD swift-http-import /bin/swift-http-import
 ENTRYPOINT ["/bin/dumb-init", "--", "/bin/swift-http-import"]


### PR DESCRIPTION
or the source repo is https or the keystone