### PR TITLE
Swift connection with region_name optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ swift:
   project_name: datastore
   project_domain_name: Default
   password: 20g82rzg235oughq
-  region_name: outer_space
 
 jobs:
   - from: http://de.archive.ubuntu.com/ubuntu/
     to:   mirror/ubuntu-repos
 ```
 
-The first paragraph contains the authentication parameters for OpenStack's Identity v3 API. Each sync job contains the
-source URL as `from`, and `to` has the target container name, optionally followed by an object name prefix in the target
-container. For example, in the case above, the file
+The first paragraph contains the authentication parameters for OpenStack's Identity v3 API. Optional a `region_name`
+can be specified.
+Each sync job contains the source URL as `from`, and `to` has the target container name, optionally followed by an 
+object name prefix in the target container. For example, in the case above, the file
 
 ```
 http://de.archive.ubuntu.com/ubuntu/pool/main/p/pam/pam_1.1.8.orig.tar.gz

--- a/config.go
+++ b/config.go
@@ -106,9 +106,6 @@ func (cfg Configuration) Validate() []error {
 	if cfg.Swift.Password == "" {
 		result = append(result, errors.New("missing value for swift.password"))
 	}
-	if cfg.Swift.RegionName == "" {
-		result = append(result, errors.New("missing value for swift.region_name"))
-	}
 
 	for idx, job := range cfg.Jobs {
 		if job.SourceRootURL == "" {


### PR DESCRIPTION
The region can be committed if the OpenStack cluster has only one region. Make `region_name` optional.