### PR TITLE
Except and Only patterns to skip directories and files on source side

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ workers:
   transfer: 10
 ```
 
+Excluding directories or files to be scraped from the source can be reached with specifying a regex in the job definition:
+```yaml
+jobs:
+  - from: http://de.archive.ubuntu.com/ubuntu/
+    to:   mirror/ubuntu-repos
+    excl: /sub_dir$|.gz$
+```
+
+This would exclude directories named `sub_dir` and files with extension `gz` on every level.
+
 ## Log output
 
 Log output on `stderr` is very sparse by default. Errors are always reported, and a final count will appear at the end like this:

--- a/README.md
+++ b/README.md
@@ -88,15 +88,31 @@ workers:
   transfer: 10
 ```
 
-Excluding directories or files to be scraped from the source can be reached with specifying a regex in the job definition:
+Restricting the scraped files before transferring them to the target can be reached with two optional job configurations:
+* `except`: Exclude directories and files which are matched by `except`
+* `only`: Exclude directories and files which are not matched by `only`
+
+The evaluation precedence is as listed.
+
+Example 1:
 ```yaml
 jobs:
-  - from: http://de.archive.ubuntu.com/ubuntu/
-    to:   mirror/ubuntu-repos
-    excl: /sub_dir$|.gz$
+  - from:   http://de.archive.ubuntu.com/ubuntu/
+    to:     mirror/ubuntu-repos
+    except: "sub_dir/$.gz$"
 ```
+This would exclude directories named `sub_dir` and files with extension `gz` on every level from scraping.
 
-This would exclude directories named `sub_dir` and files with extension `gz` on every level.
+Example 2:
+
+```yaml
+jobs:
+  - from:   http://de.archive.ubuntu.com/ubuntu/
+    to:     mirror/ubuntu-repos
+    only:   "/$|.amd64.deb$"
+```
+This would only transfer amd64 debian packages. Consider that you should allow all directories in `only` by `/$`,
+if you want to traverse the whole tree.
 
 ## Log output
 

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
+	"regexp"
 )
 
 //Job describes a single mirroring job.
@@ -38,7 +39,9 @@ type Job struct {
 	ClientCertificatePath    string `yaml:"cert"`
 	ClientCertificateKeyPath string `yaml:"key"`
 	ServerCAPath             string `yaml:"ca"`
+	ExcludePattern        	 string `yaml:"excl"`
 	HTTPClient               *http.Client
+	ExcludeRx                *regexp.Regexp
 }
 
 //Configuration contains the contents of the configuration file.
@@ -144,6 +147,9 @@ func (cfg Configuration) Validate() []error {
 			if job.ClientCertificateKeyPath == "" {
 				result = append(result, fmt.Errorf("missing value for swift.jobs[%d].key", idx))
 			}
+		}
+		if job.ExcludePattern != "" {
+			job.ExcludeRx = regexp.MustCompile(job.ExcludePattern)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -39,9 +39,11 @@ type Job struct {
 	ClientCertificatePath    string `yaml:"cert"`
 	ClientCertificateKeyPath string `yaml:"key"`
 	ServerCAPath             string `yaml:"ca"`
-	ExcludePattern        	 string `yaml:"excl"`
+	ExcludePattern        	 string `yaml:"except"`
+	IncludePattern        	 string `yaml:"only"`
 	HTTPClient               *http.Client
 	ExcludeRx                *regexp.Regexp
+	IncludeRx                *regexp.Regexp
 }
 
 //Configuration contains the contents of the configuration file.
@@ -150,6 +152,9 @@ func (cfg Configuration) Validate() []error {
 		}
 		if job.ExcludePattern != "" {
 			job.ExcludeRx = regexp.MustCompile(job.ExcludePattern)
+		}
+		if job.IncludePattern != "" {
+			job.IncludeRx = regexp.MustCompile(job.IncludePattern)
 		}
 	}
 

--- a/scraper.go
+++ b/scraper.go
@@ -108,14 +108,7 @@ func (s *Scraper) Next() []File {
 	//fetch next directory from queue
 	var directory Directory
 	s.Stack, directory = s.Stack.Pop()
-
-	//ignore explicit excluded directories, no need to drill deeper
-	if directory.Job.ExcludeRx != nil && directory.Job.ExcludeRx.MatchString(directory.Path) {
-		Log(LogDebug, "skipping %s: because of exclusion %s", directory.SourceURL(), directory.Job.ExcludePattern)
-		return nil
-	} else {
-		Log(LogDebug, "scraping %s", directory.SourceURL())
-	}
+	Log(LogDebug, "scraping %s", directory.SourceURL())
 
 	//retrieve directory listing
 	//TODO: This should send "Accept: text/html", but at least Apache and nginx
@@ -189,7 +182,12 @@ func (s *Scraper) Next() []File {
 				}
 				//ignore explicit excluded patterns
 				if directory.Job.ExcludeRx != nil && directory.Job.ExcludeRx.MatchString(href) {
-					Log(LogDebug, "skipping %s: because of exclusion %s", directory.SourceURL() + href, directory.Job.ExcludePattern)
+					Log(LogDebug, "skipping %s: is excluded by `%s`", directory.SourceURL() + href, directory.Job.ExcludePattern)
+					continue
+				}
+				//ignore not included patterns
+				if directory.Job.IncludeRx != nil && !directory.Job.IncludeRx.MatchString(href) {
+					Log(LogDebug, "skipping %s: is not included by `%s", directory.SourceURL() + href, directory.Job.IncludePattern)
 					continue
 				}
 


### PR DESCRIPTION
One Regex per job to specify exclusions on source side.
Unfortunately I didn't find an easy way to propagate the skipped dirs and files to the SharedState in the current layout. but maybe that kind of stats we can skip.