### PR TITLE
Don't delete failed upload caused by rate limit

### DIFF
--- a/pkg/objects/file.go
+++ b/pkg/objects/file.go
@@ -160,13 +160,15 @@ func (f File) uploadNormalObject(body io.Reader, sourceState FileState, hdr swif
 	if serr, ok := err.(*swift.Error); ok {
 		//upload failed due to rate limit, object is definitely not uploaded
 		//prevent additional rate limit caused by an unnecessary delete request
-		if serr.StatusCode != 498 {
-			//delete potentially incomplete upload
-			err = f.Job.Target.Connection.ObjectDelete(containerName, objectName)
-			if err != nil {
-				util.Log(util.LogError, "DELETE %s/%s failed: %s", containerName, objectName, err.Error())
-			}
+		if serr.StatusCode == 498 {
+			return false
 		}
+	}
+
+	//delete potentially incomplete upload
+	err = f.Job.Target.Connection.ObjectDelete(containerName, objectName)
+	if err != nil {
+		util.Log(util.LogError, "DELETE %s/%s failed: %s", containerName, objectName, err.Error())
 	}
 
 	return false


### PR DESCRIPTION
If the upload failed due to rate limit (HTTP 498), there is no need to delete the failed object, because it will be definitely not in Swift. The delete itself might cause an additional rate limit response.
This fix only applies to non large object uploads.

Closes partly https://github.com/sapcc/swift-http-import/issues/14