### PR TITLE
github-releases: do not list release assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Bugfixes:
 - Fixed escaping of characters in the file path of GitHub releases.
 
+Changes:
+- GitHub release assets are now mirrored under its tag name instead of
+  `releases/download/$tagName/`.
+
 # v2.9.0 (2022-05-19)
 
 New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.9.1 (TBD)
+
+Bugfixes:
+- Fixed escaping of characters in the file path of GitHub releases.
+
 # v2.9.0 (2022-05-19)
 
 New features:

--- a/pkg/objects/github.go
+++ b/pkg/objects/github.go
@@ -156,7 +156,7 @@ func (s *GithubReleaseSource) ListAllFiles(out chan<- FileSpec) *ListEntriesErro
 
 		for _, a := range r.Assets {
 			fs := FileSpec{
-				Path: fmt.Sprintf("releases/download/%s/%s", tagName, a.GetName()),
+				Path: fmt.Sprintf("%s/%s", tagName, a.GetName()),
 				// Technically, DownloadPath is supposed to be a file path but since we
 				// only need asset ID to download the asset in GetFile() therefore we can
 				// simply use the asset ID here instead.


### PR DESCRIPTION
The `github.RepositoryRelease` struct already has a slice of its release
assets therefore we don't need to make a separate API request to get a
list of release assets.

Additionally, we construct the `FileSpec.Path` manually as the JSON
response from GitHub's API will escape characters like `+` in the tag
name therefore we can not rely on `BrowserDownloadURL` field and instead
have to construct the path using `TagName` field instead.

Example:

```ShellSession
$ curl https://api.github.com/repos/k3s-io/k3s/releases/65630036
{
  "url": "https://api.github.com/repos/k3s-io/k3s/releases/65630036",
  "assets_url": "https://api.github.com/repos/k3s-io/k3s/releases/65630036/assets",
  "html_url": "https://github.com/k3s-io/k3s/releases/tag/v1.23.6%2Bk3s1",
  "id": 65630036,
  "assets": [
    {
      "url": "https://api.github.com/repos/k3s-io/k3s/releases/assets/63957182",
      "id": 63957182,
      "node_id": "RA_kwDOCBPQbs4Dz-i-",
      "name": "e2e-passed-amd64-parallel.log",
      "browser_download_url": "https://github.com/k3s-io/k3s/releases/download/v1.23.6%2Bk3s1/e2e-passed-amd64-parallel.log"
      ...
    },
    ...
  ],
  ...
}
```
