### PR TITLE
`fromEnv` syntax for Swift options and TLS client auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v2.10.0 (2023-02-28)
+
+New features:
+- Add support for specifying TLS client certificate and key file.
+- Add `{ fromEnv: ENV_VAR }` syntax support for all Swift options.
+
+Changes:
+- Updated all dependencies to their latest versions.
+
 # v2.9.1 (2022-05-25)
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ jobs:
 
 The first paragraph contains the authentication parameters for
 OpenStack's Identity v3 API. Optionally a `region_name` can be specified, but this is only
-required if there are multiple regions to choose from. You can also specify the `tls_client_certificate_path` and `tls_client_key_path` for creating a TLS client.
+required if there are multiple regions to choose from. You can also specify the `tls_client_certificate_file` and `tls_client_key_file` for creating a TLS client.
 
 You can use the `fromEnv` special syntax for the `to.container`, `to.object_prefix`, and
 the Swift fields (options under the `swift` key).

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ jobs:
 
 The first paragraph contains the authentication parameters for
 OpenStack's Identity v3 API. Optionally a `region_name` can be specified, but this is only
-required if there are multiple regions to choose from.
+required if there are multiple regions to choose from. You can also specify the `tls_client_certificate_path` and `tls_client_key_path` for creating a TLS client.
 
 You can use the `fromEnv` special syntax for the `to.container`, `to.object_prefix`, and
 the Swift fields (options under the `swift` key).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # swift-http-import
 
 * [Why this instead of rclone?](#why-this-instead-of-rclone)
-* [Do NOT use if...](#do-not-use-if)
+* [Do NOT use if\.\.\.](#do-not-use-if)
 * [Implicit assumptions](#implicit-assumptions)
 * [Installation](#installation)
 * [Usage](#usage)
+  * [Specifying sensitive info as environment variables](#specifying-sensitive-info-as-environment-variables)
   * [Alternative authentication options](#alternative-authentication-options)
   * [Source specification](#source-specification)
     * [Yum](#yum)
@@ -106,8 +107,13 @@ jobs:
       object_prefix: ubuntu-repos
 ```
 
-The first paragraph contains the authentication parameters for OpenStack's Identity v3 API. Optionally a `region_name`
-can be specified, but this is only required if there are multiple regions to choose from.
+The first paragraph contains the authentication parameters for
+OpenStack's Identity v3 API. Optionally a `region_name` can be specified, but this is only
+required if there are multiple regions to choose from.
+
+You can use the `fromEnv` special syntax for the `to.container`, `to.object_prefix`, and
+the Swift fields (options under the `swift` key).
+See [specifying sensitive info as environment variables](#specifying-sensitive-info-as-environment-variables) for more details.
 
 Each sync job contains the source URL as `from.url`, and `to.container` has the target container name, optionally paired with an
 object name prefix in the target container. For example, in the case above, the file
@@ -124,6 +130,21 @@ ubuntu-repos/pool/main/p/pam/pam_1.1.8.orig.tar.gz
 
 The order of jobs is significant: Source trees will be scraped in the order indicated by the `jobs` list.
 
+### Specifying sensitive info as environment variables
+
+For some config fields, instead of specifying the value as plain text, you can use the
+special `fromEnv` syntax to read the respective value from an exported environment
+variable.
+
+For example, instead of specifying the `swift.password` as plain text, you can use the
+following syntax to retrieve the password from the `OS_PASSWORD` environment variable:
+
+```yaml
+swift:
+  password: { fromEnv: OS_PASSWORD }
+  ...
+```
+
 ### Alternative authentication options
 
 Instead of password-based authentication, [application credentials][app-cred] can also be used, for example:
@@ -139,13 +160,6 @@ jobs: ...
 
 [app-cred]: https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/application-credentials.html
 
-Instead of providing your secret credentials as plain text in the config file, you can use a special syntax for the
-`password` field or the `application_credential_secret` field to read the respective password from an exported
-environment variable:
-
-```yaml
-password: { fromEnv: ENVIRONMENT_VARIABLE }
-```
 
 ### Source specification
 
@@ -254,8 +268,8 @@ Since GitHub's API rate limits the number of requests per IP therefore it is
 field. Refer to the [GitHub API docs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)
 for more info on its rate limiting. This field is **required** if the repository is hosted on a Github Enterprise instance instead of `github.com`.
 Instead of providing your token as plain text in the config file, you can use the
-`fromEnv` special syntax for the `jobs[].from.token` field. See [Alternative
-authentication options](#alternative-authentication-options) for more details.
+`fromEnv` special syntax for the `jobs[].from.token` field. See
+[specifying sensitive info as environment variables](#specifying-sensitive-info-as-environment-variables) for more details.
 
 If a repository publishes GitHub releases using different tags, e.g. server components at
 `server-x.y.z` and client at `client-x.y.z`, and you only want to get releases whose tag
@@ -300,6 +314,10 @@ jobs:
       container: mirror
       object_prefix: ubuntu-repos
 ```
+
+For defining Swift options, you can use the `fromEnv` special syntax for all the fields
+under the `from` key instead of specifying these fields as plain text. See
+[specifying sensitive info as environment variables](#specifying-sensitive-info-as-environment-variables)
 
 ### File selection
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca
 	github.com/majewsky/schwift v1.2.0
 	github.com/sapcc/go-api-declarations v1.4.3
-	github.com/sapcc/go-bits v0.0.0-20230214152353-488475370fbb
+	github.com/sapcc/go-bits v0.0.0-20230217073628-aeeff1f2933c
 	github.com/ulikunitz/xz v0.5.11
 	golang.org/x/crypto v0.6.0
 	golang.org/x/net v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/majewsky/schwift v1.2.0/go.mod h1:G0VE9PKSRrHo1WVnFjOuiT3RWwwNL3/ffiJ
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/sapcc/go-api-declarations v1.4.3 h1:RYJujw/NizuJepIU60E9da5JxGnWqn4FGSW/A6V7Uv8=
 github.com/sapcc/go-api-declarations v1.4.3/go.mod h1:EA4x5xxJGyG/3JTteUOYBg6cJLJgsBHrDj3ryfNU4dQ=
-github.com/sapcc/go-bits v0.0.0-20230214152353-488475370fbb h1:TA9gxarlW7559qLlbzjlAUStp9+wTnHl5IAi2qPXWyQ=
-github.com/sapcc/go-bits v0.0.0-20230214152353-488475370fbb/go.mod h1:ZyBwpzo8jYgbwlDVOmblTCF4ITUC5ZByWpVa4UCUxb0=
+github.com/sapcc/go-bits v0.0.0-20230217073628-aeeff1f2933c h1:YiPLbb/Z3LvvtfJ4EIK6BY7lWsGz2kaDbI2+KgchJ30=
+github.com/sapcc/go-bits v0.0.0-20230217073628-aeeff1f2933c/go.mod h1:ZyBwpzo8jYgbwlDVOmblTCF4ITUC5ZByWpVa4UCUxb0=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/objects/config.go
+++ b/pkg/objects/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/majewsky/schwift"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/sapcc/go-bits/secrets"
 	"github.com/sapcc/swift-http-import/pkg/util"
 )
 
@@ -74,10 +75,11 @@ func ReadConfiguration(path string) (*Configuration, []error) {
 	//across all Debian/Yum jobs.
 	var gpgCacheContainer *schwift.Container
 	if cfg.GPG.CacheContainerName != nil && *cfg.GPG.CacheContainerName != "" {
+		cntrName := *cfg.GPG.CacheContainerName
 		sl := cfg.Swift
-		sl.ContainerName = *cfg.GPG.CacheContainerName
+		sl.ContainerName = secrets.FromEnv(cntrName)
 		sl.ObjectNamePrefix = ""
-		err := sl.Connect(sl.ContainerName)
+		err := sl.Connect(cntrName)
 		if err == nil {
 			gpgCacheContainer = sl.Container
 		} else {
@@ -277,7 +279,7 @@ func (cfg JobConfiguration) Compile(name string, swift SwiftLocation) (job *Job,
 			errors = append(errors, fmt.Errorf("missing value for %s.segmenting.segment_bytes", name))
 		}
 		if cfg.Segmenting.ContainerName == "" {
-			cfg.Segmenting.ContainerName = cfg.Target.ContainerName + "_segments"
+			cfg.Segmenting.ContainerName = string(cfg.Target.ContainerName) + "_segments"
 		}
 	}
 

--- a/pkg/objects/github.go
+++ b/pkg/objects/github.go
@@ -38,11 +38,11 @@ import (
 
 type GithubReleaseSource struct {
 	// Options from config file.
-	URLString         string               `yaml:"url"`
-	Token             secrets.AuthPassword `yaml:"token"`
-	TagNamePattern    string               `yaml:"tag_name_pattern"`
-	IncludeDraft      bool                 `yaml:"include_draft"`
-	IncludePrerelease bool                 `yaml:"include_prerelease"`
+	URLString         string          `yaml:"url"`
+	Token             secrets.FromEnv `yaml:"token"`
+	TagNamePattern    string          `yaml:"tag_name_pattern"`
+	IncludeDraft      bool            `yaml:"include_draft"`
+	IncludePrerelease bool            `yaml:"include_prerelease"`
 
 	// Compiled configuration.
 	url       *url.URL       `yaml:"-"`

--- a/pkg/objects/swift.go
+++ b/pkg/objects/swift.go
@@ -39,18 +39,18 @@ import (
 // SwiftLocation contains all parameters required to establish a Swift connection.
 // It implements the Source interface, but is also used on the target side.
 type SwiftLocation struct {
-	AuthURL                     string               `yaml:"auth_url"`
-	UserName                    string               `yaml:"user_name"`
-	UserDomainName              string               `yaml:"user_domain_name"`
-	ProjectName                 string               `yaml:"project_name"`
-	ProjectDomainName           string               `yaml:"project_domain_name"`
-	Password                    secrets.AuthPassword `yaml:"password"`
-	ApplicationCredentialID     string               `yaml:"application_credential_id"`
-	ApplicationCredentialName   string               `yaml:"application_credential_name"`
-	ApplicationCredentialSecret secrets.AuthPassword `yaml:"application_credential_secret"`
-	RegionName                  string               `yaml:"region_name"`
-	ContainerName               string               `yaml:"container"`
-	ObjectNamePrefix            string               `yaml:"object_prefix"`
+	AuthURL                     string          `yaml:"auth_url"`
+	UserName                    string          `yaml:"user_name"`
+	UserDomainName              string          `yaml:"user_domain_name"`
+	ProjectName                 string          `yaml:"project_name"`
+	ProjectDomainName           string          `yaml:"project_domain_name"`
+	Password                    secrets.FromEnv `yaml:"password"`
+	ApplicationCredentialID     string          `yaml:"application_credential_id"`
+	ApplicationCredentialName   string          `yaml:"application_credential_name"`
+	ApplicationCredentialSecret secrets.FromEnv `yaml:"application_credential_secret"`
+	RegionName                  string          `yaml:"region_name"`
+	ContainerName               string          `yaml:"container"`
+	ObjectNamePrefix            string          `yaml:"object_prefix"`
 	//configuration for Validate()
 	ValidateIgnoreEmptyContainer bool `yaml:"-"`
 	//Account and Container is filled by Connect(). Container will be nil if ContainerName is empty.

--- a/pkg/objects/swift.go
+++ b/pkg/objects/swift.go
@@ -49,8 +49,8 @@ type SwiftLocation struct {
 	ApplicationCredentialID     secrets.FromEnv `yaml:"application_credential_id"`
 	ApplicationCredentialName   secrets.FromEnv `yaml:"application_credential_name"`
 	ApplicationCredentialSecret secrets.FromEnv `yaml:"application_credential_secret"`
-	TLSClientCertificatePath    secrets.FromEnv `yaml:"tls_client_certificate_path"`
-	TLSClientKeyPath            secrets.FromEnv `yaml:"tls_client_key_path"`
+	TLSClientCertificateFile    secrets.FromEnv `yaml:"tls_client_certificate_file"`
+	TLSClientKeyFile            secrets.FromEnv `yaml:"tls_client_key_file"`
 	RegionName                  secrets.FromEnv `yaml:"region_name"`
 	ContainerName               secrets.FromEnv `yaml:"container"`
 	ObjectNamePrefix            secrets.FromEnv `yaml:"object_prefix"`
@@ -91,12 +91,12 @@ func (s *SwiftLocation) Validate(name string) []error {
 		result = append(result, fmt.Errorf("missing value for %s.auth_url", name))
 	}
 
-	if s.TLSClientCertificatePath != "" || s.TLSClientKeyPath != "" {
-		if s.TLSClientCertificatePath == "" {
-			result = append(result, fmt.Errorf("missing value for %s.tls_client_certificate_path", name))
+	if s.TLSClientCertificateFile != "" || s.TLSClientKeyFile != "" {
+		if s.TLSClientCertificateFile == "" {
+			result = append(result, fmt.Errorf("missing value for %s.tls_client_certificate_file", name))
 		}
-		if s.TLSClientKeyPath == "" {
-			result = append(result, fmt.Errorf("missing value for %s.tls_client_key_path", name))
+		if s.TLSClientKeyFile == "" {
+			result = append(result, fmt.Errorf("missing value for %s.tls_client_key_file", name))
 		}
 	}
 
@@ -186,8 +186,8 @@ func (s *SwiftLocation) Connect(name string) error {
 		}
 
 		transport := &http.Transport{}
-		if s.TLSClientCertificatePath != "" && s.TLSClientKeyPath != "" {
-			cert, err := tls.LoadX509KeyPair(string(s.TLSClientCertificatePath), string(s.TLSClientKeyPath))
+		if s.TLSClientCertificateFile != "" && s.TLSClientKeyFile != "" {
+			cert, err := tls.LoadX509KeyPair(string(s.TLSClientCertificateFile), string(s.TLSClientKeyFile))
 			if err != nil {
 				return fmt.Errorf("failed to load x509 key pair: %s", err.Error())
 			}

--- a/pkg/objects/swift.go
+++ b/pkg/objects/swift.go
@@ -99,7 +99,7 @@ func (s *SwiftLocation) Validate(name string) []error {
 				result = append(result, fmt.Errorf("missing value for %s.user_domain_name", name))
 			}
 		}
-		if string(s.ApplicationCredentialSecret) == "" {
+		if s.ApplicationCredentialSecret == "" {
 			result = append(result, fmt.Errorf("missing value for %s.application_credential_secret", name))
 		}
 	} else {

--- a/vendor/github.com/sapcc/go-bits/secrets/secrets.go
+++ b/vendor/github.com/sapcc/go-bits/secrets/secrets.go
@@ -25,24 +25,22 @@ import (
 	"github.com/sapcc/go-bits/osext"
 )
 
-// AuthPassword holds either a plain text password or a key for the environment
-// variable that has the password as its value.
+// FromEnv holds either a plain text value or a key for the environment
+// variable from which the value can be retrieved.
 // The key has the format: `{ fromEnv: ENVIRONMENT_VARIABLE }`.
-//
-// If a key is given then the password is retrieved from that env variable.
-type AuthPassword string
+type FromEnv string
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (p *AuthPassword) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	//plain text password
+func (p *FromEnv) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	//plain text value
 	var plainTextInput string
 	err := unmarshal(&plainTextInput)
 	if err == nil {
-		*p = AuthPassword(plainTextInput)
+		*p = FromEnv(plainTextInput)
 		return nil
 	}
 
-	//retrieve password from the given environment variable key
+	//retrieve value from the given environment variable key
 	var envVariableInput struct {
 		Key string `yaml:"fromEnv"`
 	}
@@ -51,12 +49,12 @@ func (p *AuthPassword) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	passFromEnv, err := osext.NeedGetenv(envVariableInput.Key)
+	valFromEnv, err := osext.NeedGetenv(envVariableInput.Key)
 	if err != nil {
 		return err
 	}
 
-	*p = AuthPassword(passFromEnv)
+	*p = FromEnv(valFromEnv)
 
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/majewsky/schwift/gopherschwift
 # github.com/sapcc/go-api-declarations v1.4.3
 ## explicit; go 1.19
 github.com/sapcc/go-api-declarations/bininfo
-# github.com/sapcc/go-bits v0.0.0-20230214152353-488475370fbb
+# github.com/sapcc/go-bits v0.0.0-20230217073628-aeeff1f2933c
 ## explicit; go 1.19
 github.com/sapcc/go-bits/httpext
 github.com/sapcc/go-bits/logg


### PR DESCRIPTION
Fixes #197 and #196 .

FYI https://github.com/sapcc/go-bits/commit/aeeff1f2933c7a80e4566bcc134dc066cce0815d .