### PR TITLE
Fix lints

### DIFF
--- a/pkg/objects/github.go
+++ b/pkg/objects/github.go
@@ -163,7 +163,8 @@ func (s *GithubReleaseSource) ListAllFiles(_ context.Context, out chan<- FileSpe
 				DownloadPath: strconv.FormatInt(a.GetID(), 10),
 			}
 			if a.UpdatedAt != nil {
-				fs.LastModified = &a.UpdatedAt.Time
+				updatedAtTime := a.UpdatedAt.Time
+				fs.LastModified = &updatedAtTime
 			}
 			out <- fs
 		}


### PR DESCRIPTION
This fixes:
  G601: Implicit memory aliasing in for loop. (gosec)