### PR TITLE
fix modernize

### DIFF
--- a/pkg/objects/config.go
+++ b/pkg/objects/config.go
@@ -162,7 +162,7 @@ type SourceUnmarshaler struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (u *SourceUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (u *SourceUnmarshaler) UnmarshalYAML(unmarshal func(any) error) error {
 	// unmarshal a few indicative fields
 	var probe struct {
 		URL  string `yaml:"url"`

--- a/pkg/objects/datatypes.go
+++ b/pkg/objects/datatypes.go
@@ -46,7 +46,7 @@ var (
 )
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (a *AgeSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (a *AgeSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var input string
 	err := unmarshal(&input)
 	if err != nil {

--- a/pkg/objects/debian.go
+++ b/pkg/objects/debian.go
@@ -258,7 +258,7 @@ func (s *DebianSource) listDistFiles(ctx context.Context, distRootPath string, c
 }
 
 // Helper function for DebianSource.ListAllFiles().
-func (s *DebianSource) downloadAndParseDCF(ctx context.Context, path string, data interface{}, cache map[string]FileSpec) (contents []byte, uri string, e *ListEntriesError) {
+func (s *DebianSource) downloadAndParseDCF(ctx context.Context, path string, data any, cache map[string]FileSpec) (contents []byte, uri string, e *ListEntriesError) {
 	buf, uri, lerr := s.urlSource.getFileContents(ctx, path, cache)
 	if lerr != nil {
 		return nil, uri, lerr

--- a/pkg/objects/swift.go
+++ b/pkg/objects/swift.go
@@ -134,8 +134,8 @@ type logger struct {
 	Prefix string
 }
 
-func (l logger) Printf(format string, args ...interface{}) {
-	for _, v := range strings.Split(fmt.Sprintf(format, args...), "\n") {
+func (l logger) Printf(format string, args ...any) {
+	for v := range strings.SplitSeq(fmt.Sprintf(format, args...), "\n") {
 		logg.Debug("[%s] %s", l.Prefix, v)
 	}
 }

--- a/pkg/objects/yum.go
+++ b/pkg/objects/yum.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"io"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/majewsky/schwift/v2"
@@ -206,16 +207,11 @@ func (s *YumSource) handlesArchitecture(arch string) bool {
 	if len(s.Architectures) == 0 || arch == "" {
 		return true
 	}
-	for _, val := range s.Architectures {
-		if val == arch {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Architectures, arch)
 }
 
 // Helper function for YumSource.ListAllFiles().
-func (s *YumSource) downloadAndParseXML(ctx context.Context, path string, data interface{}, cache map[string]FileSpec) (contents []byte, uri string, e *ListEntriesError) {
+func (s *YumSource) downloadAndParseXML(ctx context.Context, path string, data any, cache map[string]FileSpec) (contents []byte, uri string, e *ListEntriesError) {
 	buf, uri, lerr := s.urlSource.getFileContents(ctx, path, cache)
 	if lerr != nil {
 		return nil, uri, lerr


### PR DESCRIPTION
config.go, datatypes.go, debian.go, swift.go, yum.go: use any instead of interface{}
yum.go, swift.go: use slices.contains, use SplitSeq